### PR TITLE
Add a job picker component

### DIFF
--- a/src/components/plugins/JobConfigPicker.vue
+++ b/src/components/plugins/JobConfigPicker.vue
@@ -1,0 +1,107 @@
+<!--
+  - Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div>
+    <btn @click="modalOpen=true">
+      <slot>Choose A Job &hellip;</slot>
+    </btn>
+
+    <modal v-model="modalOpen" :title="'Choose A Job'" ref="modal" append-to-body>
+
+      <div v-if="showProjectSelector"><label>Project:</label><project-picker v-model="project"></project-picker></div>
+
+      <div class="list-group" v-for="(item,name) in jobTree.groups" :key="'group'+name">
+        <div class="list-group-item" v-if="name && item.jobs.length>0">
+           <h4 class="list-group-item-heading">{{item.label}}</h4>
+        </div>
+        <div v-for="job in item.jobs" :key="job.id"
+             class="list-group-item"
+             style="overflow:hidden; text-overflow: ellipsis; white-space: nowrap"
+             >
+
+             <a href="#" class="" :title="'Choose this job: '+job.id"
+                   @click="selectedJob=job">
+                 <i class="glyphicon glyphicon-book"></i>
+                 {{job.name}}
+             </a>
+
+
+            <span class="text-primary">
+              {{job.description}}
+            </span>
+
+
+        </div>
+      </div>
+      <div slot="footer">
+        <btn @click="modalOpen=false">Cancel</btn>
+      </div>
+
+    </modal>
+  </div>
+</template>
+<script lang="ts">
+import { JobReference } from '../../interfaces/JobReference'
+import { JobTree } from '../../types/JobTree'
+import { GroupedJobs, TreeItem } from '../../types/TreeItem'
+import { Job } from 'ts-rundeck/dist/lib/models'
+import Vue from 'vue'
+import ProjectPicker from './ProjectPicker.vue'
+import { Component, Prop, Watch } from 'vue-property-decorator'
+import { client } from '../../modules/rundeckClient'
+
+Vue.component("project-picker",ProjectPicker)
+
+@Component
+export default class JobConfigPicker extends Vue {
+  @Prop({ required: false, default: '' })
+  value!: string
+
+  selectedJob: JobReference | null = null
+  modalOpen: boolean = false
+  jobs: Job[] = []
+  jobTree: JobTree = new JobTree()
+  project: string = ''
+  showProjectSelector: boolean = true
+
+@Watch('project')
+  loadJobs() {
+    this.jobTree = new JobTree()
+    if(this.project != '') {
+      client.jobList(this.project).then(result => {
+        this.jobs = result
+        this.jobs.forEach(job => this.jobTree.insert(job))
+      })
+    }
+  }
+
+  @Watch('selectedJob')
+  jobChosen() {
+    this.modalOpen = false
+    this.$emit('input', this.selectedJob ? this.selectedJob.id : '')
+  }
+
+  mounted() {
+    if(window._rundeck.projectName) {
+      this.showProjectSelector = false
+      this.project = window._rundeck.projectName
+    }
+  }
+}
+</script>
+<style lang="scss">
+</style>

--- a/src/components/plugins/ProjectPicker.vue
+++ b/src/components/plugins/ProjectPicker.vue
@@ -1,0 +1,57 @@
+<!--
+  - Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div>
+    <select v-bind:value="value" v-on:input="$emit('input',$event.target.value)" class="form-control">
+        <option v-for="project in projects" :key="project" v-bind:value="project">{{project}}</option>
+    </select>
+  </div>
+</template>
+<script lang="ts">
+import { JobReference } from '../../interfaces/JobReference'
+import { JobTree } from '../../types/JobTree'
+import { GroupedJobs, TreeItem } from '../../types/TreeItem'
+import { Job } from 'ts-rundeck/dist/lib/models'
+import Vue from 'vue'
+import { Component, Prop, Watch } from 'vue-property-decorator'
+import { client } from '../../modules/rundeckClient'
+
+
+
+@Component
+export default class ProjectPicker extends Vue {
+  @Prop({ required: false, default: '' })
+  value!: string
+
+  projects: string[] = []
+
+  loadProjects() {
+      this.projects.push('')
+      client.projectList().then(result => {
+          result.forEach(prj => {
+              if(prj.name) this.projects.push(prj.name)
+          })
+      })
+  }
+
+  mounted() {
+    this.loadProjects()
+  }
+}
+</script>
+<style lang="scss">
+</style>

--- a/src/components/plugins/pluginConfig.vue
+++ b/src/components/plugins/pluginConfig.vue
@@ -103,7 +103,6 @@ import Vue from 'vue'
 
 import AceEditor from '../utils/AceEditor.vue'
 import Expandable from '../utils/Expandable.vue'
-// import JobConfigPicker from './JobConfigPicker.vue'
 import PluginInfo from './PluginInfo.vue'
 import PluginValidation from '../../interfaces/PluginValidation'
 import PluginPropView from './pluginPropView.vue'
@@ -125,7 +124,6 @@ export default Vue.extend({
   components: {
     Expandable,
     AceEditor,
-    // JobConfigPicker,
     PluginInfo,
     PluginPropView,
     PluginPropEdit
@@ -362,7 +360,6 @@ export default Vue.extend({
       return convertArrayInput(cleanConfigInput(this.exportInputs()))
     }
   },
-
   beforeMount () {
     this.loadForMode()
   }

--- a/src/interfaces/JobReference.ts
+++ b/src/interfaces/JobReference.ts
@@ -1,0 +1,12 @@
+export interface JobReference {
+    id: string
+    name: string
+    group: string
+    project: string
+    description: string
+    href: string
+    permalink: string
+    scheduled: boolean
+    scheduleEnabled: boolean
+    enabled: boolean
+  }

--- a/src/types/JobTree.ts
+++ b/src/types/JobTree.ts
@@ -1,0 +1,33 @@
+
+import { Job } from 'ts-rundeck/dist/lib/models'
+import { GroupedJobs, TreeItem } from './TreeItem'
+
+export class JobTree implements GroupedJobs {
+  groups: { [name: string]: TreeItem } = {}
+  constructor() {
+    this.groups[''] = new TreeItem('')
+  }
+  subPath(item: TreeItem, part: string, create: boolean = true): TreeItem {
+    if (part === '') {
+      return item
+    }
+
+    const path = item.name + '/' + part
+    if (!this.groups[path]) {
+      this.groups[path] = new TreeItem(path)
+    }
+    return this.groups[path]
+  }
+  locateTreeItem(group: string): TreeItem {
+    const groups = group.split(/\//)
+    let curitem = this.groups['']
+    groups.forEach(part => {
+      curitem = this.subPath(curitem, part)
+    })
+    return curitem
+  }
+  insert(job: Job) {
+    const item = this.locateTreeItem(job.group || '')
+    if(item.jobs.indexOf(job) == -1) item.jobs.push(job)
+  }
+}

--- a/src/types/TreeItem.ts
+++ b/src/types/TreeItem.ts
@@ -1,0 +1,17 @@
+
+import { Job } from 'ts-rundeck/dist/lib/models'
+export class TreeItem {
+  name: string
+  jobs: Job[]
+  label: string
+
+  constructor(name: string) {
+    this.name = name
+    this.jobs = []
+    this.label = name.charAt(0) === '/' ? name.substring(1) : name
+  }
+}
+
+export interface GroupedJobs {
+  groups: { [name: string]: TreeItem }
+}


### PR DESCRIPTION
Add a job picker component that handles plugin properties whose display type is RUNDECK_JOB.

The job picker filters the jobs by project if the user is in the context of a project.